### PR TITLE
Bug/explicitly require set

### DIFF
--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -1,4 +1,5 @@
-require "behaves/version"
+require 'behaves/version'
+require 'set'
 
 module Behaves
   def implements(*methods)

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Behaves do
 
   context 'when `Dog` is supposed to behave like `Animal`' do
     before do
+      Dog = Class.new
       Animal = Class.new do
         extend Behaves
 
@@ -18,8 +19,6 @@ RSpec.describe Behaves do
 
     context 'when `Dog` implements behavior' do
       it 'should not raise error' do
-        Dog = Class.new
-
         expect do
           Dog.class_eval do
             extend Behaves
@@ -36,7 +35,6 @@ RSpec.describe Behaves do
     context 'when `Dog` does not implement behavior' do
       it 'should raise NotImplementedError' do
         skip "Skipping because the code implementation (`at_exit`) conflicts with rspec's `raise_error`. See https://github.com/rspec/rspec/issues/42"
-        Dog = Class.new
 
         expect do
           Dog.class_eval do
@@ -44,7 +42,6 @@ RSpec.describe Behaves do
 
             behaves_like Animal
           end
-        # end.to raise_error NotImplementedError
         end.to raise_error NotImplementedError, "Expected `Animal` to define behaviors, but none found."
       end
     end
@@ -52,9 +49,9 @@ RSpec.describe Behaves do
 
   context 'when `Dog` is not supposed to behave like `Animal`' do
     it 'should not raise any error' do
-      Dog = Class.new
-
       expect do
+        Dog = Class.new
+
         Dog.class_eval do
           extend Behaves
 
@@ -67,12 +64,13 @@ RSpec.describe Behaves do
 
   context 'when `Animal` does not implement behavior' do
     context 'when `Dog` adheres to a non-existent `Animal` behavior' do
-      skip "Skipping because the code implementation (`at_exit`) conflicts with rspec's `raise_error`. See https://github.com/rspec/rspec/issues/42"
       it 'should raise error' do
+        skip "Skipping because the code implementation (`at_exit`) conflicts with rspec's `raise_error`. See https://github.com/rspec/rspec/issues/42"
         Animal = Class.new
+        Dog = Class.new
 
         expect do
-          Dog = Class.new do
+          Dog.class_eval do
             extend Behaves
 
             behaves_like Animal
@@ -85,6 +83,6 @@ RSpec.describe Behaves do
   private
 
   def class_cleaner(*klasses)
-    klasses.each { |klass| Object.send(:remove_const, "#{klass}") unless defined? klass }
+    klasses.each { |klass| Object.send(:remove_const, "#{klass}") if defined? klass }
   end
 end


### PR DESCRIPTION
[Set](https://ruby-doc.org/stdlib-2.6.3/libdoc/set/rdoc/Set.html) had always been a `stdlib`, not a core lib, thus an explicit `require set` is required in order to use it.

The test has been passing without it and I have no idea why, but here's to making it more explicit.

---

Refactor test
- DRY-ed up initialization of `Dog` whenever possible
- Fix class not being cleaned due to inverted logic (`unless` vs
`defined`)