### PR TITLE
Refactor `behaves_like` implementation to fix spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    behaves (0.1.0)
+    behaves (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -7,20 +7,22 @@ module Behaves
   end
 
   def behaves_like(klass)
-    at_exit do
-      required = defined_behaviors(klass)
-
-      implemented = Set.new(self.instance_methods - Object.instance_methods)
-
-      unimplemented = required - implemented
-
-      exit if unimplemented.empty?
-
-      raise NotImplementedError, "Expected `#{self}` to behave like `#{klass}`, but `#{unimplemented.to_a.join(', ')}` are not implemented."
-    end
+    at_exit { check_for_unimplemented(klass) }
   end
 
   private
+
+  def check_for_unimplemented(klass)
+    required = defined_behaviors(klass)
+
+    implemented = Set.new(self.instance_methods - Object.instance_methods)
+
+    unimplemented = required - implemented
+
+    return if unimplemented.empty?
+
+    raise NotImplementedError, "Expected `#{self}` to behave like `#{klass}`, but `#{unimplemented.to_a.join(', ')}` are not implemented."
+  end
 
   def defined_behaviors(klass)
     if behaviors = klass.instance_variable_get("@behaviors")

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -3,26 +3,27 @@ RSpec.describe Behaves do
     expect(Behaves::VERSION).not_to be nil
   end
 
+  before do
+    monkey_patch_behaves
+    Dog = Class.new
+    Animal = Class.new
+  end
+
+  after do
+    class_cleaner(Animal, Dog)
+  end
+
   context 'when `Dog` is supposed to behave like `Animal`' do
     before do
-      Dog = Class.new
-      Animal = Class.new do
-        extend Behaves
-
+      Animal.class_eval do
         implements :method_one, :method_two
       end
-    end
-
-    after do
-      class_cleaner(Animal, Dog)
     end
 
     context 'when `Dog` implements behavior' do
       it 'should not raise error' do
         expect do
           Dog.class_eval do
-            extend Behaves
-
             behaves_like Animal
 
             def method_one; end
@@ -34,15 +35,9 @@ RSpec.describe Behaves do
 
     context 'when `Dog` does not implement behavior' do
       it 'should raise NotImplementedError' do
-        skip "Skipping because the code implementation (`at_exit`) conflicts with rspec's `raise_error`. See https://github.com/rspec/rspec/issues/42"
-
         expect do
-          Dog.class_eval do
-            extend Behaves
-
-            behaves_like Animal
-          end
-        end.to raise_error NotImplementedError, "Expected `Animal` to define behaviors, but none found."
+          Dog.send(:check_for_unimplemented, Animal) # Since I can't test `at_exit`, I'm testing the private method directly.
+        end.to raise_error NotImplementedError, "Expected `Dog` to behave like `Animal`, but `method_one, method_two` are not implemented."
       end
     end
   end
@@ -50,11 +45,7 @@ RSpec.describe Behaves do
   context 'when `Dog` is not supposed to behave like `Animal`' do
     it 'should not raise any error' do
       expect do
-        Dog = Class.new
-
         Dog.class_eval do
-          extend Behaves
-
           def method_one; end
           def method_two; end
         end
@@ -65,22 +56,18 @@ RSpec.describe Behaves do
   context 'when `Animal` does not implement behavior' do
     context 'when `Dog` adheres to a non-existent `Animal` behavior' do
       it 'should raise error' do
-        skip "Skipping because the code implementation (`at_exit`) conflicts with rspec's `raise_error`. See https://github.com/rspec/rspec/issues/42"
-        Animal = Class.new
-        Dog = Class.new
-
         expect do
-          Dog.class_eval do
-            extend Behaves
-
-            behaves_like Animal
-          end
+          Dog.send(:check_for_unimplemented, Animal) # Since I can't test `at_exit`, I'm testing the private method directly.
         end.to raise_error NotImplementedError, "Expected `Animal` to define behaviors, but none found."
       end
     end
   end
 
   private
+
+  def monkey_patch_behaves
+    Object.send(:extend, Behaves)
+  end
 
   def class_cleaner(*klasses)
     klasses.each { |klass| Object.send(:remove_const, "#{klass}") if defined? klass }


### PR DESCRIPTION
A reply is given for the [RSpec issue](https://github.com/rspec/rspec-expectations/issues/1117), I've
reviewed the proposed solution and found that I'd take a different approach instead in order to fix the `at_exit` spec.

First off, this commit extracts out the core logic for `behaves_like` into a `private` method. This is important for a couple of reason.

By extracting it out, `behaves_like` now only consists of the `at_exit` logic, and because I can't test `at_exit` due to the nature of it, I've decided to test directly on the newly extracted `private` method.

While it is generally frowned upon to test private methods (you should be testing the public interfaces only!!), and I do agree on that on a general case, I think that this is an exceptional situation that calls
for a break of rules.

**Guidelines should be all that is, guides, it should not be rules that prevent innovation**. Thus I've decided to break the rule this time.

Fixes #2