### PR TITLE
CI: Drop unused Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
----
-sudo: false
 language: ruby
 cache: bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: ruby
-cache: bundler
-rvm:
-  - 2.3.1
-before_install: gem install bundler -v 1.17.1


### PR DESCRIPTION
- See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details