### PR TITLE
Feature/allow behavior injection

### DIFF
--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -6,6 +6,10 @@ module Behaves
     @behaviors ||= Set.new(methods)
   end
 
+  def inject_behaviours (&block)
+    @injected_behaviours ||= block
+  end
+
   def behaves_like(klass)
     at_exit { check_for_unimplemented(klass) }
   end

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -12,6 +12,7 @@ module Behaves
 
   def behaves_like(klass)
     at_exit { check_for_unimplemented(klass) }
+    add_injected_behaviours(klass)
   end
 
   private

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -35,4 +35,10 @@ module Behaves
       raise NotImplementedError, "Expected `#{klass}` to define behaviors, but none found."
     end
   end
+
+  def injected_behaviours(klass)
+    if inject_behaviours = klass.instance_variable_get("@injected_behaviours")
+      inject_behaviours
+    end
+  end
 end

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -6,12 +6,12 @@ module Behaves
     @behaviors ||= Set.new(methods)
   end
 
-  def inject_behaviours (&block)
-    @injected_behaviours ||= block
+  def inject_behaviors (&block)
+    @inject_behaviors ||= block
   end
 
   def behaves_like(klass)
-    add_injected_behaviours(klass)
+    add_injected_behaviors(klass)
     at_exit { check_for_unimplemented(klass) }
   end
 
@@ -37,16 +37,16 @@ module Behaves
     end
   end
 
-  def add_injected_behaviours(klass)
-    injected_behaviours = injected_behaviours(klass)
-    if injected_behaviours
-      self.class_eval &injected_behaviours
+  def add_injected_behaviors(klass)
+    injected_behaviors = klass.instance_variable_get("@inject_behaviors")
+    if injected_behaviors
+      self.class_eval &injected_behaviors
     end
   end
 
-  def injected_behaviours(klass)
-    if inject_behaviours = klass.instance_variable_get("@injected_behaviours")
-      inject_behaviours
+  def injected_behaviors(klass)
+    if injected_behaviors = klass.instance_variable_get("@inject_behaviors")
+      injected_behaviors
     end
   end
 end

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -36,6 +36,13 @@ module Behaves
     end
   end
 
+  def add_injected_behaviours(klass)
+    injected_behaviours = injected_behaviours(klass)
+    if injected_behaviours
+      self.class_eval &injected_behaviours
+    end
+  end
+
   def injected_behaviours(klass)
     if inject_behaviours = klass.instance_variable_get("@injected_behaviours")
       inject_behaviours

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -43,10 +43,4 @@ module Behaves
       self.class_eval &injected_behaviors
     end
   end
-
-  def injected_behaviors(klass)
-    if injected_behaviors = klass.instance_variable_get("@inject_behaviors")
-      injected_behaviors
-    end
-  end
 end

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -11,8 +11,8 @@ module Behaves
   end
 
   def behaves_like(klass)
-    at_exit { check_for_unimplemented(klass) }
     add_injected_behaviours(klass)
+    at_exit { check_for_unimplemented(klass) }
   end
 
   private

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -184,6 +184,74 @@ RSpec.describe Behaves do
         expect(Dog.new.send(:greet)).to eq("bonjour")
       end
     end
+
+    context "injecting to include module" do
+      TestModule = Module.new
+
+      before do
+        TestModule.module_eval do
+          def greet
+            "hello"
+          end
+        end
+
+        Animal.class_eval do
+          implements :method_one
+
+          inject_behaviors do
+            include TestModule
+          end
+        end
+
+        Dog.class_eval do
+          behaves_like Animal
+
+          def method_one; end
+        end
+      end
+
+      it "should add greet as an instance method to Dog" do
+        expect(Dog.instance_methods).to include(:greet)
+      end
+
+      it "should return the correct result when greet is invoked from Dog" do
+        expect(Dog.new.greet).to eq("hello")
+      end
+    end
+
+    context "injecting to extend a module" do
+      TestModule = Module.new
+
+      before do
+        TestModule.module_eval do
+          def greet
+            "hello"
+          end
+        end
+
+        Animal.class_eval do
+          implements :method_one
+
+          inject_behaviors do
+            extend TestModule
+          end
+        end
+
+        Dog.class_eval do
+          behaves_like Animal
+
+          def method_one; end
+        end
+      end
+
+      it "should add greet as a class method to Dog" do
+        expect(Dog.methods).to include(:greet)
+      end
+
+      it "should return the correct result when greet is invoked from Dog" do
+        expect(Dog.greet).to eq("hello")
+      end
+    end
   end
 
   private

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -63,6 +63,129 @@ RSpec.describe Behaves do
     end
   end
 
+  context "when Animal injects" do
+    context "public behavior to Dog" do
+      before do
+        Animal.class_eval do
+          implements :method_one
+          
+          inject_behaviors do
+            def greet
+              "hello"
+            end
+          end
+        end
+
+        Dog.class_eval do
+          behaves_like Animal
+          
+          def method_one; end
+        end
+      end
+      
+      it "should have the injected behavior" do
+        expect(Dog.instance_methods).to include(:greet)
+      end
+
+      it "should return the correct output when invoked" do
+        expect(Dog.new.greet).to eq("hello")
+      end
+    end
+
+    context "public behavior to Dog, but Dog has a function with the same name defined" do
+      before do
+        Animal.class_eval do
+          implements :method_one
+          
+          inject_behaviors do
+            def greet
+              "hello"
+            end
+          end
+        end
+
+        Dog.class_eval do
+          behaves_like Animal
+          
+          def method_one; end
+          
+          def greet
+            "bonjour"
+          end
+        end
+      end
+
+      it "should return the correct output from the function defined in Dog instead" do
+        expect(Dog.new.greet).to eq("bonjour")
+      end
+    end
+  end
+
+  context "when Animal injects" do
+    context "private behavior to Dog" do
+    
+      before do
+        Animal.class_eval do
+          implements :method_one
+          
+          inject_behaviors do      
+            private 
+
+            def greet
+              "hello"
+            end
+          end
+        end
+
+        Dog.class_eval do
+          behaves_like Animal
+          
+          def method_one; end
+        end
+      end
+
+      it "should have the injected behavior" do
+        expect(Dog.private_instance_methods).to include(:greet)
+      end
+
+      it "should return the correct output when invoked" do
+        expect(Dog.new.send(:greet)).to eq("hello")
+      end
+    end
+
+    context "private behavior to Dog, but Dog has a private function defined with the same name" do
+      before do
+        Animal.class_eval do
+          implements :method_one
+          
+          inject_behaviors do       
+            private
+
+            def greet
+              "hello"
+            end
+          end
+        end
+
+        Dog.class_eval do
+          behaves_like Animal
+
+          def method_one; end
+
+          private
+          
+          def greet
+            "bonjour"
+          end
+        end
+      end
+
+      it "should return the correct output when invoked" do
+        expect(Dog.new.send(:greet)).to eq("bonjour")
+      end
+    end
+  end
+
   private
 
   def monkey_patch_behaves


### PR DESCRIPTION
This PR introduces the feature to enable the behaviour class to inject behaviours to the behaving class, through the `.inject_behaviors` function.

Sample Usage
------

```
class Animal
  extend Behaves

  implements :speak

  inject_behaviours do
    def bonjour
      puts "bonjour"
    end
  end
end

class Dog
  extend Behaves

  behaves_like Animal

  def speak
    bonjour
  end
end

dog = Dog.new
dog.speak   -> invokes the function `bonjour` injected from Animal. # bonjour
```

Fixes #15 