### PR TITLE
Allow definition of private behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,35 @@ This extends to more than just method implementation too, you can do anything yo
 
 *Do note that if you use this extensively, you might be better off using inheritance, since this will create more `Method` objects than inheritance.*
 
+### Private Behaviors
+
+Private behaviors can be defined like so:
+
+```ruby
+class Interface
+  extend Behaves
+
+  implements :foo
+  implements :bar, private: true
+end
+
+class Implementor
+  extend Behaves
+
+  behaves_like Interface
+
+  def foo
+    123
+  end
+
+  private
+
+  def bar
+    456
+  end
+end
+```
+
 ## Tips
 If you do not want to type `extend Behaves` every time, you can monkey patch `Behaves` onto `Object` class, like so:
 

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -34,7 +34,10 @@ module Behaves
 
     return if unimplemented.empty?
 
-    raise NotImplementedError, "Expected `#{self}` to behave like `#{klass}`, but #{scope} methods `#{unimplemented.to_a.join(', ')}` are not implemented."
+    raise NotImplementedError, <<~ERR
+      \n\n  Expected `#{self}` to behave like `#{klass}`, but the following #{scope} methods are unimplemented:\n
+      #{unimplemented.to_a.map{|sym| "    * `#{sym}`"}.join("\n")}\n
+    ERR
   end
 
   def implemented(scope)

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -27,27 +27,27 @@ module Behaves
 
   private
 
-  def check_for_unimplemented(klass, type = :public)
-    required = defined_behaviors(klass, type)
+  def check_for_unimplemented(klass, scope)
+    required = defined_behaviors(klass, scope)
 
-    unimplemented = required - implemented(type)
+    unimplemented = required - implemented(scope)
 
     return if unimplemented.empty?
 
-    raise NotImplementedError, "Expected `#{self}` to behave like `#{klass}`, but #{type} methods `#{unimplemented.to_a.join(', ')}` are not implemented."
+    raise NotImplementedError, "Expected `#{self}` to behave like `#{klass}`, but #{scope} methods `#{unimplemented.to_a.join(', ')}` are not implemented."
   end
 
-  def implemented(type)
+  def implemented(scope)
     lookups = {
       public:           :instance_methods,
       private:  :private_instance_methods,
     }
 
-    method_lookup_sym = lookups.fetch(type) do
+    method_lookup_sym = lookups.fetch(scope) do
       raise ArgumentError.new <<~ERR
 
-        Invalid `type`: #{type}
-        Valid `type`s include: #{types.keys.map{|sym| "`#{sym.inspect}`"}.join(', ')}
+        Invalid `scope`: #{scope}
+        Valid `scope`s include: #{lookups.keys.map{|sym| "`#{sym.inspect}`"}.join(', ')}
       ERR
     end
 
@@ -56,8 +56,8 @@ module Behaves
     Set.new(methods)
   end
 
-  def defined_behaviors(klass, type)
-    if behaviors = klass.instance_variable_get(:"@_#{type}_behaviors")
+  def defined_behaviors(klass, scope)
+    if behaviors = klass.instance_variable_get(:"@_#{scope}_behaviors")
       behaviors
     else
       raise NotImplementedError, "Expected `#{klass}` to define behaviors, but none found."

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -34,10 +34,30 @@ module Behaves
 
     return if unimplemented.empty?
 
-    raise NotImplementedError, <<~ERR
+
+    # basic "unimplemented method" error message
+
+    err = <<~ERR
       \n\n  Expected `#{self}` to behave like `#{klass}`, but the following #{scope} methods are unimplemented:\n
-      #{unimplemented.to_a.map{|sym| "    * `#{sym}`"}.join("\n")}\n
+      #{unimplemented.to_a.map{|method| "    * `#{method}`"}.join("\n")}\n
     ERR
+
+
+    # add "wrong scope" message
+
+    other_scopes            = (scope == :public) ? [:private] : [:public]
+    methods_in_other_scopes = Set.new( other_scopes.map{|s| implemented(s)}.map(&:to_a).flatten.compact )
+    methods_in_wrong_scope  = unimplemented && methods_in_other_scopes
+
+    if !methods_in_wrong_scope.empty?
+      err += <<~ERR
+        \n  The following methods appear to be defined, but in the wrong scope:\n
+        #{methods_in_wrong_scope.to_a.map{|method| "    * `#{method}`"}.join("\n")}\n\n
+      ERR
+    end
+
+
+    raise NotImplementedError, err
   end
 
   def implemented(scope)

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -3,7 +3,8 @@ require 'set'
 
 module Behaves
   def implements(*methods)
-    @behaviors ||= Set.new(methods)
+    @_Behaves_behaviors ||= Set.new
+    @_Behaves_behaviors  += Set.new(methods)
   end
 
   def inject_behaviors (&block)
@@ -20,7 +21,7 @@ module Behaves
   def check_for_unimplemented(klass)
     required = defined_behaviors(klass)
 
-    implemented = Set.new(self.instance_methods - Object.instance_methods)
+    implemented = Set.new(self.instance_methods(false))
 
     unimplemented = required - implemented
 
@@ -30,7 +31,7 @@ module Behaves
   end
 
   def defined_behaviors(klass)
-    if behaviors = klass.instance_variable_get("@behaviors")
+    if behaviors = klass.instance_variable_get(:@_Behaves_behaviors)
       behaviors
     else
       raise NotImplementedError, "Expected `#{klass}` to define behaviors, but none found."

--- a/lib/behaves.rb
+++ b/lib/behaves.rb
@@ -2,9 +2,15 @@ require 'behaves/version'
 require 'set'
 
 module Behaves
-  def implements(*methods)
-    @_Behaves_behaviors ||= Set.new
-    @_Behaves_behaviors  += Set.new(methods)
+  def implements(*methods, **opts)
+    @_Behaves_public_behaviors  ||= Set.new
+    @_Behaves_private_behaviors ||= Set.new
+
+    if opts[:private] == true
+      @_Behaves_private_behaviors += Set.new(methods)
+    else
+      @_Behaves_public_behaviors  += Set.new(methods)
+    end
   end
 
   def inject_behaviors (&block)
@@ -13,25 +19,37 @@ module Behaves
 
   def behaves_like(klass)
     add_injected_behaviors(klass)
-    at_exit { check_for_unimplemented(klass) }
+    at_exit {
+      check_for_unimplemented(klass, :public)
+      check_for_unimplemented(klass, :private)
+    }
   end
 
   private
 
-  def check_for_unimplemented(klass)
-    required = defined_behaviors(klass)
+  def check_for_unimplemented(klass, type = :public)
+    required = defined_behaviors(klass, type)
 
-    implemented = Set.new(self.instance_methods(false))
-
-    unimplemented = required - implemented
+    unimplemented = required - implemented(type)
 
     return if unimplemented.empty?
 
-    raise NotImplementedError, "Expected `#{self}` to behave like `#{klass}`, but `#{unimplemented.to_a.join(', ')}` are not implemented."
+    raise NotImplementedError, "Expected `#{self}` to behave like `#{klass}`, but #{type} methods `#{unimplemented.to_a.join(', ')}` are not implemented."
   end
 
-  def defined_behaviors(klass)
-    if behaviors = klass.instance_variable_get(:@_Behaves_behaviors)
+  def implemented(type)
+    implemented = Set.new(
+      case type
+      when :public  then         instance_methods(false)
+      when :private then private_instance_methods(false)
+      else
+        raise ArgumentError.new("Invalid `type`: #{type}")
+      end
+    )
+  end
+
+  def defined_behaviors(klass, type)
+    if behaviors = klass.instance_variable_get(:"@_Behaves_#{type}_behaviors")
       behaviors
     else
       raise NotImplementedError, "Expected `#{klass}` to define behaviors, but none found."

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Behaves do
       context 'when `Dog` does not implement behavior' do
         it 'should raise NotImplementedError' do
           expect do
-            Dog.send(:check_for_unimplemented, Animal) # Since I can't test `at_exit`, I'm testing the private method directly.
+            Dog.send(:check_for_unimplemented, Animal, :public) # Since I can't test `at_exit`, I'm testing the private method directly.
           end.to raise_error NotImplementedError, "Expected `Dog` to behave like `Animal`, but public methods `method_one, method_two, method_three` are not implemented."
         end
       end
@@ -65,7 +65,7 @@ RSpec.describe Behaves do
     context 'when `Dog` adheres to a non-existent `Animal` behavior' do
       it 'should raise error' do
         expect do
-          Dog.send(:check_for_unimplemented, Animal) # Since I can't test `at_exit`, I'm testing the private method directly.
+          Dog.send(:check_for_unimplemented, Animal, :public) # Since I can't test `at_exit`, I'm testing the private method directly.
         end.to raise_error NotImplementedError, "Expected `Animal` to define behaviors, but none found."
       end
     end

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Behaves do
     context 'via public methods' do
       context 'when `Dog` implements behavior' do
         it 'should not raise error' do
+          class Foo
+            # behaves_like Animal
+
+            private
+            def method_one; end
+          end
+
           expect do
             Dog.class_eval do
               behaves_like Animal
@@ -274,8 +281,6 @@ RSpec.describe Behaves do
       it 'raises no errors' do
         expect do
           Implementor.class_eval do
-            behaves_like Interface
-
             def foo; end
 
             private
@@ -292,8 +297,6 @@ RSpec.describe Behaves do
         it 'raises an error' do
           expect do
             Implementor.class_eval do
-              behaves_like Interface
-
               def foo; end
               def bar; end
             end
@@ -309,8 +312,6 @@ RSpec.describe Behaves do
       it 'raises an error' do
         expect do
           Implementor.class_eval do
-            behaves_like Interface
-
             def foo; end
           end
 

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -7,37 +7,44 @@ RSpec.describe Behaves do
     monkey_patch_behaves
     Dog = Class.new
     Animal = Class.new
+
+    Interface = Class.new
+    Impementor = Class.new
   end
 
   after do
-    class_cleaner(Animal, Dog)
+    class_cleaner(Animal, Dog, Interface, Impementor)
   end
 
   context 'when `Dog` is supposed to behave like `Animal`' do
     before do
       Animal.class_eval do
         implements :method_one, :method_two
+        implements :method_three
       end
     end
 
-    context 'when `Dog` implements behavior' do
-      it 'should not raise error' do
-        expect do
-          Dog.class_eval do
-            behaves_like Animal
+    context 'via public methods' do
+      context 'when `Dog` implements behavior' do
+        it 'should not raise error' do
+          expect do
+            Dog.class_eval do
+              behaves_like Animal
 
-            def method_one; end
-            def method_two; end
-          end
-        end.not_to raise_error
+              def method_one; end
+              def method_two; end
+              def method_three; end
+            end
+          end.not_to raise_error
+        end
       end
-    end
 
-    context 'when `Dog` does not implement behavior' do
-      it 'should raise NotImplementedError' do
-        expect do
-          Dog.send(:check_for_unimplemented, Animal) # Since I can't test `at_exit`, I'm testing the private method directly.
-        end.to raise_error NotImplementedError, "Expected `Dog` to behave like `Animal`, but `method_one, method_two` are not implemented."
+      context 'when `Dog` does not implement behavior' do
+        it 'should raise NotImplementedError' do
+          expect do
+            Dog.send(:check_for_unimplemented, Animal) # Since I can't test `at_exit`, I'm testing the private method directly.
+          end.to raise_error NotImplementedError, "Expected `Dog` to behave like `Animal`, but `method_one, method_two, method_three` are not implemented."
+        end
       end
     end
   end
@@ -48,6 +55,7 @@ RSpec.describe Behaves do
         Dog.class_eval do
           def method_one; end
           def method_two; end
+          def method_three; end
         end
       end.not_to raise_error
     end

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Behaves do
         it 'should raise NotImplementedError' do
           expect do
             Dog.send(:check_for_unimplemented, Animal, :public) # Since I can't test `at_exit`, I'm testing the private method directly.
-          end.to raise_error NotImplementedError, "Expected `Dog` to behave like `Animal`, but public methods `method_one, method_two, method_three` are not implemented."
+          end.to raise_error NotImplementedError, %r"Expected `Dog` to behave like `Animal`, but the following public methods.+`method_one`.+`method_two`.+`method_three`"m
         end
       end
     end
@@ -303,7 +303,7 @@ RSpec.describe Behaves do
 
             Implementor.send(:check_for_unimplemented, Interface, :public)
             Implementor.send(:check_for_unimplemented, Interface, :private)
-          end.to raise_error NotImplementedError, %r(private methods `bar`)
+          end.to raise_error NotImplementedError, %r(private methods.+`bar`)m
         end
       end
     end
@@ -317,7 +317,7 @@ RSpec.describe Behaves do
 
           Implementor.send(:check_for_unimplemented, Interface, :public)
           Implementor.send(:check_for_unimplemented, Interface, :private)
-        end.to raise_error NotImplementedError, %r(private methods `bar`)
+        end.to raise_error NotImplementedError, %r(private methods.+`bar`)m
       end
     end
   end

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe Behaves do
 
             Implementor.send(:check_for_unimplemented, Interface, :public)
             Implementor.send(:check_for_unimplemented, Interface, :private)
-          end.to raise_error NotImplementedError, %r(private methods.+`bar`)m
+          end.to raise_error NotImplementedError, %r(private methods.+`bar`.+appear to be defined, but in the wrong scope.+`bar`)m
         end
       end
     end

--- a/spec/behaves_spec.rb
+++ b/spec/behaves_spec.rb
@@ -287,6 +287,22 @@ RSpec.describe Behaves do
           Implementor.send(:check_for_unimplemented, Interface, :private)
         end.not_to raise_error
       end
+
+      context 'but in the wrong scope' do
+        it 'raises an error' do
+          expect do
+            Implementor.class_eval do
+              behaves_like Interface
+
+              def foo; end
+              def bar; end
+            end
+
+            Implementor.send(:check_for_unimplemented, Interface, :public)
+            Implementor.send(:check_for_unimplemented, Interface, :private)
+          end.to raise_error NotImplementedError, %r(private methods `bar`)
+        end
+      end
     end
 
     context 'when unimplemented' do


### PR DESCRIPTION
Hey! Thanks so much for this gem! I was just wishing the other day that something like this existed, and here it is! :slightly_smiling_face: :tada: 

So, I'm not sure that anyone else actually cares about this use case, but I needed it, and figured I'd offer the changes back upstream. Here's the gist:

```ruby
class Interface
  extend Behaves

  implements :foo
  implements :bar, private: true
end

class Implementor
  extend Behaves

  behaves_like Interface

  def foo
    123
  end

  private

  def bar
    456
  end
end
```